### PR TITLE
0.1.6 merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,8 @@ Version 0.1.5 (12/29/2020)
 
 [![GoDoc](https://godoc.org/github.com/gonyyi/alog?status.svg)](https://godoc.org/github.com/gonyyi/alog)
 [![Go Reference](https://pkg.go.dev/badge/github.com/gonyyi/alog.svg)](https://pkg.go.dev/github.com/gonyyi/alog@v0.1.5)
-[![license](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/gonyyi/alog/master/LICENSE)
-
+[![License](http://img.shields.io/badge/license-MIT-red.svg?style=flat)](https://raw.githubusercontent.com/gonyyi/alog/master/LICENSE)
+[![Coverage](http://gocover.io/_badge/github.com/gonyyi/alog)](http://gocover.io/github.com/gonyyi/alog)
 
 ## Table of Contents
 

--- a/alog.go
+++ b/alog.go
@@ -4,6 +4,7 @@
 // 0.1.6c2: for methods that can be often called by other logger compatible interfaces, Debugf() may be used just as
 //    a Debug() without additional params of interface (a). So, new version will check the length of additional param
 //    and if it's zero (0), then run it as Debug() instead of Debugf().
+// 0.1.6c3: Added `*Logger.IfError(error)` and `*Logger.IfFatal(error)` which only log when error is not nil.
 
 package alog
 
@@ -393,6 +394,16 @@ func (l *Logger) Warnf(format string, a ...interface{}) {
 	}
 }
 
+// IfError will check and log error if exist (not nil)
+// For instance, when running multiple lines of error check
+// This can save error checking.
+// added as v0.1.6c3, 12/30/2020
+func (l *Logger) IfError(e error) {
+	if e != nil {
+		l.Print(Lerror, noCategory, e.Error())
+	}
+}
+
 // Error will take a single string and print log without category
 func (l *Logger) Error(s string) {
 	l.Print(Lerror, noCategory, s)
@@ -408,6 +419,18 @@ func (l *Logger) Errorf(format string, a ...interface{}) {
 		l.mu.Lock()
 		l.printf(Lerror, 0, format, a...)
 		l.mu.Unlock()
+	}
+}
+
+// IfFatal will check and log error if exist (not nil)
+// For instance, when running multiple lines of error check
+// This can save error checking.
+// Unlikee IfError, IfFatal will exit the program
+// added as v0.1.6c3, 12/30/2020
+func (l *Logger) IfFatal(e error) {
+	if e != nil {
+		l.Print(Lfatal, noCategory, e.Error())
+		os.Exit(1)
 	}
 }
 

--- a/alog.go
+++ b/alog.go
@@ -1,10 +1,12 @@
 // (c) 2020 Gon Y Yi. <https://gonyyi.com>
-// Version 0.1.6c2, 12/29/2020
+// Version 0.1.6, 12/30/2020
 
 // 0.1.6c2: for methods that can be often called by other logger compatible interfaces, Debugf() may be used just as
 //    a Debug() without additional params of interface (a). So, new version will check the length of additional param
 //    and if it's zero (0), then run it as Debug() instead of Debugf().
 // 0.1.6c3: Added `*Logger.IfError(error)` and `*Logger.IfFatal(error)` which only log when error is not nil.
+// 0.1.6c4: Added `*Logger.Close()` method.
+
 
 package alog
 
@@ -427,22 +429,27 @@ func (l *Logger) Errorf(format string, a ...interface{}) {
 // This can save error checking.
 // Unlikee IfError, IfFatal will exit the program
 // added as v0.1.6c3, 12/30/2020
+// updated with Close() as v0.1.6c4, 12/30/2020
 func (l *Logger) IfFatal(e error) {
 	if e != nil {
 		l.Print(Lfatal, noCategory, e.Error())
+		l.Close()
 		os.Exit(1)
 	}
 }
 
 // Fatal will take a single string and print log without category
 // and this will terminate process with exit code 1
+// updated with Close() as v0.1.6c4, 12/30/2020
 func (l *Logger) Fatal(s string) {
 	l.Print(Lfatal, noCategory, s)
+	l.Close()
 	os.Exit(1)
 }
 
 // Fatalf will formats and print log without category
 // and this will terminate process with exit code 1
+// updated with Close() as v0.1.6c4, 12/30/2020
 func (l *Logger) Fatalf(format string, a ...interface{}) {
 	if len(a) == 0 {
 		l.Print(Lfatal, noCategory, format)
@@ -453,12 +460,22 @@ func (l *Logger) Fatalf(format string, a ...interface{}) {
 		l.printf(Lfatal, noCategory, format, a...)
 		l.mu.Unlock()
 	}
+	l.Close()
 	os.Exit(1)
 }
 
 // Writer returns the output destination for the logger.
 func (l *Logger) Writer() io.Writer {
 	return l.out
+}
+
+// Close will call .Close() method if supported
+// Added for v0.1.6c4, 12/30/2020
+func (l *Logger) Close() error {
+	if c, ok := l.out.(io.Closer); ok && c != nil {
+		return c.Close()
+	}
+	return nil
 }
 
 // NewPrint takes level and category and create a print function.

--- a/alog.go
+++ b/alog.go
@@ -1,5 +1,9 @@
 // (c) 2020 Gon Y Yi. <https://gonyyi.com>
-// Version 0.1.6c, 12/29/2020
+// Version 0.1.6c2, 12/29/2020
+
+// 0.1.6c2: for methods that can be often called by other logger compatible interfaces, Debugf() may be used just as
+//    a Debug() without additional params of interface (a). So, new version will check the length of additional param
+//    and if it's zero (0), then run it as Debug() instead of Debugf().
 
 package alog
 
@@ -324,6 +328,10 @@ func (l *Logger) Trace(s string) {
 
 // Tracef will formats and print log without category
 func (l *Logger) Tracef(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Ltrace, noCategory, format)
+		return
+	}
 	if l.check(Ltrace, noCategory) {
 		l.mu.Lock()
 		l.printf(Ltrace, noCategory, format, a...)
@@ -338,6 +346,10 @@ func (l *Logger) Debug(s string) {
 
 // Debugf will formats and print log without category
 func (l *Logger) Debugf(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Ldebug, noCategory, format)
+		return
+	}
 	if l.check(Ldebug, noCategory) {
 		l.mu.Lock()
 		l.printf(Ldebug, noCategory, format, a...)
@@ -352,6 +364,10 @@ func (l *Logger) Info(s string) {
 
 // Infof will formats and print log without category
 func (l *Logger) Infof(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Linfo, noCategory, format)
+		return
+	}
 	if l.check(Linfo, noCategory) {
 		l.mu.Lock()
 		l.printf(Linfo, noCategory, format, a...)
@@ -366,6 +382,10 @@ func (l *Logger) Warn(s string) {
 
 // Warnf will formats and print log without category
 func (l *Logger) Warnf(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Lwarn, noCategory, format)
+		return
+	}
 	if l.check(Lwarn, noCategory) {
 		l.mu.Lock()
 		l.printf(Lwarn, noCategory, format, a...)
@@ -380,6 +400,10 @@ func (l *Logger) Error(s string) {
 
 // Errorf will formats and print log without category
 func (l *Logger) Errorf(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Lerror, noCategory, format)
+		return
+	}
 	if l.check(Lerror, noCategory) {
 		l.mu.Lock()
 		l.printf(Lerror, 0, format, a...)
@@ -397,6 +421,10 @@ func (l *Logger) Fatal(s string) {
 // Fatalf will formats and print log without category
 // and this will terminate process with exit code 1
 func (l *Logger) Fatalf(format string, a ...interface{}) {
+	if len(a) == 0 {
+		l.Print(Lfatal, noCategory, format)
+		return
+	}
 	if l.check(Lfatal, noCategory) {
 		l.mu.Lock()
 		l.printf(Lfatal, noCategory, format, a...)

--- a/alog_test.go
+++ b/alog_test.go
@@ -10,6 +10,29 @@ import (
 	"testing"
 )
 
+
+// added as v0.1.6c3, 12/30/2020
+func TestLogger_IfError(t *testing.T) {
+	out := &bytes.Buffer{}
+	l := alog.New(out, "log ", alog.Fprefix|alog.Flevel)
+
+	// create a new error object, at this point this should be nil, and calling err.Error() will cause a panic
+	var err error
+	l.IfError(err)
+	err = errors.New("test error") // now error exists
+	l.IfError(err)
+	err = nil // empty err again with nil
+	l.IfError(err)
+	err = errors.New("again another one") // now error exists again
+	l.IfError(err)
+
+	expected := "log [ERR] test error\nlog [ERR] again another one\n"
+
+	if expected != out.String() {
+		t.Errorf("expected=<%s>, actual=<%s>", expected, out.String())
+	}
+}
+
 func TestBasic(t *testing.T) {
 	// NoLevel will use INFO as its level.
 	t.Run("Print,NoLevel", func(t2 *testing.T) {


### PR DESCRIPTION
- Added a badge for a coverage
- Any level-predefined and formatted methods such as `Tracef`, `Debugf`, ... `Fatalf` will evaluate if any additional arguments are present besides format string. If there is no additional argument, it will run without formatting to save processing time.
- `*.Logger.IfError(error)`, `*.Logger.IfFatal(error)` has been added. These methods are taking error (or `nil`) for an argument. If it's `nil`, it will ignore, but if actual error is given, it will log the error message. 
- `*Logger.Close()` method has been added back. If an `io.Writer` that logger uses have `Close()` method, it will call the `Close()` method of the writer.
- `Fatal`, `Fatalf`, `IfFatal` will call `*Logger.Close()` right before the `os.Exit()`
